### PR TITLE
Added an option to suppress a startup warning about local Conda env

### DIFF
--- a/plugin/vimconda.py
+++ b/plugin/vimconda.py
@@ -66,6 +66,9 @@ msg_suppress = int(vim.eval('exists("g:conda_startup_msg_suppress")'))
 if msg_suppress:
     msg_suppress = int(vim.eval('g:conda_startup_msg_suppress'))
 
+wrn_suppress = int(vim.eval('exists("g:conda_startup_wrn_suppress")'))
+if wrn_suppress:
+    wrn_suppress = int(vim.eval('g:conda_startup_wrn_suppress'))
 
 def python_input(message='input'):
     vim.command('call inputsave()')
@@ -286,13 +289,14 @@ def conda_startup_env():
         print('Found more than one matching env, '
               'this should never happen.')
     elif len(roots) == 0:
-        print('\nCould not find a matching env in the list. '
-              '\nThis probably means that you are using a local '
-              '\n(prefix) Conda env.'
-              '\n '
-              '\nThis should be fine, but changing to a named env '
-              '\nmay make it difficult to reactivate the prefix env.'
-              '\n ')
+        if not wrn_suppress:
+            print('\nCould not find a matching env in the list. '
+                  '\nThis probably means that you are using a local '
+                  '\n(prefix) Conda env.'
+                  '\n '
+                  '\nThis should be fine, but changing to a named env '
+                  '\nmay make it difficult to reactivate the prefix env.'
+                  '\n ')
         vim.command('let g:conda_startup_was_prefix = 1')
     else:
         root = roots[0]


### PR DESCRIPTION
When opening vim without activating an environment first, I would receive the following warning:
```
Could not find a matching env in the list. 
This probably means that you are using a local 
(prefix) Conda env.
 
This should be fine, but changing to a named env 
may make it difficult to reactivate the prefix env.
 
Press ENTER or type command to continue
```
To avoid this additional ENTER keystroke whenever I opened a file in vim without an environment activated, I added an option to suppress this warning. 
Simply add `let g:conda_startup_wrn_suppress = 1` to your `.vimrc`. If you set `let g:conda_startup_wrn_suppress = 0`, everything will be as before.
