### PR TITLE
Use CONDA_EXE to run conda info

### DIFF
--- a/plugin/vimconda.py
+++ b/plugin/vimconda.py
@@ -208,7 +208,7 @@ def get_conda_info_dict():
       "user_rc_path": "/Users/calebhattingh/.condarc"
     }
     """
-    output = vim_conda_runshell('conda info --json')
+    output = vim_conda_runshell('$CONDA_EXE info --json')
     return json.loads(output)
 
 


### PR DESCRIPTION
Compared to the shell function `conda`, the environment variable `CONDA_EXE` is more easily controllable from within `vim`, which comes handy when using a GUI.

This change shouldn't break the functionality of `conda info` except for requiring minimum `conda` version of `4.5` (https://github.com/conda/conda/pull/6923), which is reasonable.