### PR TITLE
Raise more informative error when $CONDA_EXE can't be run

### DIFF
--- a/plugin/vimconda.py
+++ b/plugin/vimconda.py
@@ -12,7 +12,7 @@ compatible code at http://python-future.org/compatible_idioms.html """
 # For Python2 compatibility
 from __future__ import print_function
 
-from subprocess import check_output, PIPE
+from subprocess import check_output, CalledProcessError, PIPE
 
 import copy
 import json
@@ -208,8 +208,12 @@ def get_conda_info_dict():
       "user_rc_path": "/Users/calebhattingh/.condarc"
     }
     """
-    output = vim_conda_runshell('$CONDA_EXE info --json')
-    return json.loads(output)
+    try:
+        output = vim_conda_runshell('$CONDA_EXE info --json')
+        return json.loads(output)
+    except CalledProcessError:
+        cmd = vim_conda_runshell('echo $CONDA_EXE').strip()
+        raise RuntimeError(f"$CONDA_EXE is not set to a valid conda executable ($CONDA_EXE='{cmd}')") from None
 
 
 def insert_system_py_sitepath():

--- a/plugin/vimconda.py
+++ b/plugin/vimconda.py
@@ -213,7 +213,7 @@ def get_conda_info_dict():
         return json.loads(output)
     except CalledProcessError:
         cmd = vim_conda_runshell('echo $CONDA_EXE').strip()
-        raise RuntimeError(f"$CONDA_EXE is not set to a valid conda executable ($CONDA_EXE='{cmd}')") from None
+        raise RuntimeError("$CONDA_EXE is not set to a valid conda executable ($CONDA_EXE='{}')".format(cmd)) from None
 
 
 def insert_system_py_sitepath():


### PR DESCRIPTION
When $CONDA_EXE is not set (as in #36 ), the resulting error message is not that informative for the end user (`subprocess.CalledProcessError: Command '$CONDA_EXE info --json' returned non-zero exit status 1.`). I've tried replacing this with a message that points the user in the right direction. Not sure whether something more specific than `RuntimeError` would be appropriate; let me know if I should change it.