### PR TITLE
Shifted from using raw $CONDA_EXE to os.getenv

### DIFF
--- a/plugin/vimconda.py
+++ b/plugin/vimconda.py
@@ -209,10 +209,11 @@ def get_conda_info_dict():
     }
     """
     try:
-        output = vim_conda_runshell('$CONDA_EXE info --json')
+        conda_exe = os.getenv('CONDA_EXE')
+        output = vim_conda_runshell(conda_exe + ' info --json')
         return json.loads(output)
     except CalledProcessError:
-        cmd = vim_conda_runshell('echo $CONDA_EXE').strip()
+        cmd = vim_conda_runshell('echo ' + conda_exe).strip()
         raise RuntimeError("$CONDA_EXE is not set to a valid conda executable ($CONDA_EXE='{}')".format(cmd)) from None
 
 


### PR DESCRIPTION
Used os.getenv('CONDA_EXE') rather than $CONDA_EXE to address issue where MS Windows doesn't recognize the $CONDA_EXE format. I've only been able to test on Windows 10, but I would expect that the os.getenv functionality should be functional across systems.